### PR TITLE
tests: refine e2e test (check CPU is reset, adjust ratio for comparison)

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -36,8 +36,8 @@ fi
 python_with_boost_pod_uid=$(kubectl get pods python-with-boost -o jsonpath='{.metadata.uid}' | sed 's~-~_~g')
 python_with_boost_python_container_id=$(kubectl get pods python-with-boost -o jsonpath='{.status.containerStatuses[?(@.name=="python")].containerID}' | cut -d '/' -f 3)
 
-docker exec -it kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cpu.max > pod_cpu.max
-docker exec -it kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cri-containerd-${python_with_boost_python_container_id}.scope/cpu.max > python_container_cpu.max
+docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cpu.max > pod_cpu.max
+docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cri-containerd-${python_with_boost_python_container_id}.scope/cpu.max > python_container_cpu.max
 
 if ! diff -b <(cat pod_cpu.max) <(echo "5000 100000")
 then


### PR DESCRIPTION
Fixes #1.

In the PR #2 creating the e2e test, I've missed the last point in issue #1:

> - check the cgroup cpu.max related to the pod with the boost label is back to its default value

This updates the e2e test.

Also, changed the ratio from 5 to 3 to ensure test always pass: sometimes (e.g. https://github.com/norbjd/k8s-pod-cpu-booster/actions/runs/6137691209/job/16653782767), we have a 4.5 ratio, but actually, 3 times faster is fine too.