### PR TITLE
chore: replace label to enable CPU boost with an annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ Install `k8s-pod-cpu-booster`:
 KO_DOCKER_REPO=kind.local ko apply -f config/
 ```
 
-Start two similar pods with low CPU limits and running `python -m http.server`, with a readiness probe configured to check when the http server is started. The only differences are the name (obviously), and the label `norbjd/k8s-pod-cpu-booster-enabled`:
+Start two similar pods with low CPU limits and running `python -m http.server`, with a readiness probe configured to check when the http server is started. The only differences are the name (obviously), and the annotation `norbjd.github.io/k8s-pod-cpu-booster-enabled`:
 
 ```diff
 --- examples/python-no-boost.yaml
 +++ examples/python-with-boost.yaml
 @@ -4 +4,3 @@
 -  name: python-no-boost
-+  labels:
-+    norbjd/k8s-pod-cpu-booster-enabled: "true"
++  annotations:
++    norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
 +  name: python-with-boost
 ```
 
-As a result, the pod `python-with-boost` (with the label) will benefit from a CPU boost, but `python-no-boost` won't:
+As a result, the pod `python-with-boost` (with the annotation) will benefit from a CPU boost, but `python-no-boost` won't:
 
 ```sh
 kubectl apply -f examples/python-no-boost.yaml -f examples/python-with-boost.yaml

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	cpuBoostStartupLabel  = "norbjd/k8s-pod-cpu-booster-enabled"
-	cpuBoostMultiplicator = 10
+	cpuBoostStartupAnnotation = "norbjd.github.io/k8s-pod-cpu-booster-enabled"
+	cpuBoostMultiplicator     = 10
 )
 
 // Inspired by:
@@ -80,7 +80,7 @@ func onUpdate(oldObj interface{}, newObj interface{}) {
 		oldPod.Namespace, oldPod.Name,
 	)
 
-	if podHasBoostLabel(newPod) {
+	if podHasBoostAnnotation(newPod) {
 		if len(newPod.Status.ContainerStatuses) == 0 {
 			klog.Infof("pod %s/%s has no container statuses, skipping...", newPod.Namespace, newPod.Name)
 			return
@@ -113,8 +113,8 @@ func onUpdate(oldObj interface{}, newObj interface{}) {
 	}
 }
 
-func podHasBoostLabel(pod *corev1.Pod) bool {
-	boost, ok := pod.Labels[cpuBoostStartupLabel]
+func podHasBoostAnnotation(pod *corev1.Pod) bool {
+	boost, ok := pod.Annotations[cpuBoostStartupAnnotation]
 	return ok && boost == "true"
 }
 

--- a/examples/python-with-boost.yaml
+++ b/examples/python-with-boost.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  labels:
-    norbjd/k8s-pod-cpu-booster-enabled: "true"
+  annotations:
+    norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
   name: python-with-boost
 spec:
   containers:

--- a/test/e2e/python-with-boost.yaml
+++ b/test/e2e/python-with-boost.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  labels:
-    norbjd/k8s-pod-cpu-booster-enabled: "true"
+  annotations:
+    norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
   name: python-with-boost
 spec:
   containers:


### PR DESCRIPTION
I feel like an annotation is more suitable than a label to enable a feature.