### PR TITLE
chore: split code into multiple packages

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,37 +1,16 @@
 package main
 
 import (
-	"errors"
 	"flag"
-	"fmt"
-	"os"
-	"path"
-	"strconv"
-	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/informers/internalinterfaces"
+	cgroupv2_containerd_kind "github.com/norbjd/k8s-pod-cpu-booster/pkg/cgroup/cgroupv2/containerd/kind"
+	"github.com/norbjd/k8s-pod-cpu-booster/pkg/informer"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
-const (
-	cpuBoostStartupAnnotation = "norbjd.github.io/k8s-pod-cpu-booster-enabled"
-
-	cpuBoostMultiplierAnnotation = "norbjd.github.io/k8s-pod-cpu-booster-multiplier"
-	cpuBoostDefaultMultiplier    = uint64(10)
-)
-
-// Inspired by:
-// - https://www.cncf.io/blog/2019/10/15/extend-kubernetes-via-a-shared-informer/
-// TODO: split in multiple packages
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -46,196 +25,9 @@ func main() {
 		panic(err)
 	}
 
-	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, informers.WithTweakListOptions(podCPUBoosterTweakFunc()))
-	informer := factory.Core().V1().Pods().Informer()
+	// TODO: detect automatically the right cgroup handler to use
+	// only support Kind + containerd + cgroups v2 for now
+	cgroupHandler := cgroupv2_containerd_kind.Cgroupv2ContainerdKindHandler{}
 
-	stopper := make(chan struct{})
-	defer close(stopper)
-	defer runtime.HandleCrash()
-
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: onUpdate,
-	})
-
-	go informer.Run(stopper)
-	klog.Infof("Informer started!")
-
-	if !cache.WaitForCacheSync(stopper, informer.HasSynced) {
-		runtime.HandleError(errors.New("timed out waiting for caches to sync"))
-		return
-	}
-
-	<-stopper
-}
-
-// only check pods running on the current node, assumes NODE_NAME contains the name of the node
-func podCPUBoosterTweakFunc() internalinterfaces.TweakListOptionsFunc {
-	return func(opts *metav1.ListOptions) {
-		opts.FieldSelector = "spec.nodeName=" + os.Getenv("NODE_NAME")
-	}
-}
-
-func getBoostMultiplierFromAnnotations(pod *corev1.Pod) uint64 {
-	if boostMultiplierAnnotationValue, ok := pod.Annotations["cpuBoostMultiplierAnnotation"]; ok {
-		boostMultiplierAnnotationValueInt, err := strconv.ParseUint(boostMultiplierAnnotationValue, 10, 64)
-		if err != nil {
-			klog.Errorf("boost multiplier is not a valid value, will take the default %d instead: %s",
-				cpuBoostDefaultMultiplier, err.Error())
-			return cpuBoostDefaultMultiplier
-		}
-
-		return boostMultiplierAnnotationValueInt
-	}
-
-	return cpuBoostDefaultMultiplier
-}
-
-func onUpdate(oldObj interface{}, newObj interface{}) {
-	oldPod := oldObj.(*corev1.Pod)
-	newPod := newObj.(*corev1.Pod)
-	klog.Infof(
-		"pod %s/%s updated",
-		oldPod.Namespace, oldPod.Name,
-	)
-
-	if podHasBoostAnnotation(newPod) {
-		if len(newPod.Status.ContainerStatuses) == 0 {
-			klog.Infof("pod %s/%s has no container statuses, skipping...", newPod.Namespace, newPod.Name)
-			return
-		}
-
-		if len(newPod.Spec.Containers) != 1 {
-			klog.Infof("pod %s/%s contains %d containers, skipping...", newPod.Namespace, newPod.Name, len(newPod.Spec.Containers))
-			return
-		}
-
-		podUID := newPod.UID
-		containerID := newPod.Status.ContainerStatuses[0].ContainerID // this is same to use [0] as we've checked above if we have 1 container
-
-		initialCPULimit := newPod.Spec.Containers[0].Resources.Limits.Cpu()
-		boostMultiplier := getBoostMultiplierFromAnnotations(newPod)
-
-		// once ready, we reset the CPU as the normal limit
-		if podPassedFromNotReadyToReady(oldPod, newPod) {
-			klog.Infof("will reset %s/%s CPU limit to default", newPod.Namespace, newPod.Name)
-			err := resetCPUBoost(podUID, containerID, initialCPULimit)
-			if err != nil {
-				klog.Errorf("error while resetting CPU boost: %s", err.Error())
-			}
-		} else { // TODO: do that only once
-			klog.Infof("will boost %s/%s CPU limit", newPod.Namespace, newPod.Name)
-			err := boostCPU(podUID, containerID, initialCPULimit, boostMultiplier)
-			if err != nil {
-				klog.Errorf("error while boosting CPU: %s", err.Error())
-			}
-		}
-	}
-}
-
-func podHasBoostAnnotation(pod *corev1.Pod) bool {
-	boost, ok := pod.Annotations[cpuBoostStartupAnnotation]
-	return ok && boost == "true"
-}
-
-func podPassedFromNotReadyToReady(oldPod, newPod *corev1.Pod) bool {
-	podWasNotReady := false
-
-	for _, condition := range oldPod.Status.Conditions {
-		if condition.Type == "Ready" && condition.Status == "False" {
-			podWasNotReady = true
-			break
-		}
-	}
-
-	if podWasNotReady {
-		for _, condition := range newPod.Status.Conditions {
-			if condition.Type == "Ready" && condition.Status == "True" {
-				klog.Infof(
-					"pod %s/%s is now ready",
-					oldPod.Namespace, oldPod.Name,
-				)
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func quantityToCPULimit(quantity *resource.Quantity) uint64 {
-	return uint64(quantity.AsApproximateFloat64() * 100_000.)
-}
-
-func boostCPU(podUID types.UID, containerID string, initialCPULimit *resource.Quantity, boostMultiplier uint64) error {
-	klog.Infof("CPU limit: %d", quantityToCPULimit(initialCPULimit))
-	cgroupCPULimitAfterBoost := quantityToCPULimit(initialCPULimit) * boostMultiplier
-	klog.Infof("New cgroup cpu limit to: %d", cgroupCPULimitAfterBoost)
-
-	err := writeCgroupCPUMax(podUID, containerID, cgroupCPULimitAfterBoost)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func resetCPUBoost(podUID types.UID, containerID string, initialCPULimit *resource.Quantity) error {
-	cgroupCPULimitAfterReset := quantityToCPULimit(initialCPULimit)
-	klog.Infof("Reset cgroup cpu limit to: %d", cgroupCPULimitAfterReset)
-
-	err := writeCgroupCPUMax(podUID, containerID, cgroupCPULimitAfterReset)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// TODO: works ONLY with kind + containerd + cgroup v2
-// TODO: create an interface and implement with "Containerd cgroup v2", "Containerd cgroup v1", etc.
-func getPodCgroupSliceDirectory(podUID types.UID) string {
-	return fmt.Sprintf(
-		"/sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod%s.slice",
-		strings.ReplaceAll(string(podUID), "-", "_"),
-	)
-}
-
-func getContainerCgroupScopeDirectory(podCgroupSliceDirectory, containerID string) string {
-	containerID = strings.Replace(containerID, "containerd://", "", 1) // assumes only containerd
-	return fmt.Sprintf(
-		"%s/cri-containerd-%s.scope",
-		podCgroupSliceDirectory,
-		containerID,
-	)
-}
-
-// TODO: write only if file exists. Try to understand when the file is available
-func writeCgroupCPUMax(podUID types.UID, containerID string, newCPUMax uint64) error {
-	podCgroupSliceDirectory := getPodCgroupSliceDirectory(podUID)
-	containerCgroupScopeDirectory := getContainerCgroupScopeDirectory(podCgroupSliceDirectory, containerID)
-
-	podCgroupCPUMaxFile := path.Join(podCgroupSliceDirectory, "cpu.max")
-	containerCgroupCPUMaxFile := path.Join(containerCgroupScopeDirectory, "cpu.max")
-
-	newCPUMaxFileContents := fmt.Sprintf("%d 100000", newCPUMax)
-
-	klog.Infof("will write %s to %s and %s", newCPUMaxFileContents, podCgroupCPUMaxFile, containerCgroupCPUMaxFile)
-
-	err := os.WriteFile(podCgroupCPUMaxFile, []byte(newCPUMaxFileContents), 0o644)
-	if err != nil {
-		return fmt.Errorf("cannot write to %s: %w", podCgroupCPUMaxFile, err)
-	}
-
-	err = os.WriteFile(containerCgroupCPUMaxFile, []byte(newCPUMaxFileContents), 0o644)
-	if err != nil {
-		return fmt.Errorf("cannot write to %s: %w", containerCgroupCPUMaxFile, err)
-	}
-
-	podCgroupCPUMaxFileContents, _ := os.ReadFile(podCgroupCPUMaxFile)
-	klog.Infof("pod cpu.max: %s", string(podCgroupCPUMaxFileContents))
-
-	containerCgroupCPUMaxFileContents, _ := os.ReadFile(containerCgroupCPUMaxFile)
-	klog.Infof("container cpu.max: %s", string(containerCgroupCPUMaxFileContents))
-
-	return nil
+	informer.Run(clientset, cgroupHandler)
 }

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -1,0 +1,7 @@
+package cgroup
+
+import "k8s.io/apimachinery/pkg/types"
+
+type CgroupHandler interface {
+	WriteCPUMax(podUID types.UID, containerID string, cpuMaxValue uint64) error
+}

--- a/pkg/cgroup/cgroupv2/containerd/kind/kind.go
+++ b/pkg/cgroup/cgroupv2/containerd/kind/kind.go
@@ -1,0 +1,60 @@
+package cgroupv2_containerd_kind
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+type Cgroupv2ContainerdKindHandler struct{}
+
+// TODO: write only if file exists. Try to understand when the file is available
+func (m Cgroupv2ContainerdKindHandler) WriteCPUMax(podUID types.UID, containerID string, newCPUMax uint64) error {
+	podCgroupSliceDirectory := getPodCgroupSliceDirectory(podUID)
+	containerCgroupScopeDirectory := getContainerCgroupScopeDirectory(podCgroupSliceDirectory, containerID)
+
+	podCgroupCPUMaxFile := path.Join(podCgroupSliceDirectory, "cpu.max")
+	containerCgroupCPUMaxFile := path.Join(containerCgroupScopeDirectory, "cpu.max")
+
+	newCPUMaxFileContents := fmt.Sprintf("%d 100000", newCPUMax)
+
+	klog.Infof("will write %s to %s and %s", newCPUMaxFileContents, podCgroupCPUMaxFile, containerCgroupCPUMaxFile)
+
+	err := os.WriteFile(podCgroupCPUMaxFile, []byte(newCPUMaxFileContents), 0o644)
+	if err != nil {
+		return fmt.Errorf("cannot write to %s: %w", podCgroupCPUMaxFile, err)
+	}
+
+	err = os.WriteFile(containerCgroupCPUMaxFile, []byte(newCPUMaxFileContents), 0o644)
+	if err != nil {
+		return fmt.Errorf("cannot write to %s: %w", containerCgroupCPUMaxFile, err)
+	}
+
+	podCgroupCPUMaxFileContents, _ := os.ReadFile(podCgroupCPUMaxFile)
+	klog.Infof("pod cpu.max: %s", string(podCgroupCPUMaxFileContents))
+
+	containerCgroupCPUMaxFileContents, _ := os.ReadFile(containerCgroupCPUMaxFile)
+	klog.Infof("container cpu.max: %s", string(containerCgroupCPUMaxFileContents))
+
+	return nil
+}
+
+func getPodCgroupSliceDirectory(podUID types.UID) string {
+	return fmt.Sprintf(
+		"/sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod%s.slice",
+		strings.ReplaceAll(string(podUID), "-", "_"),
+	)
+}
+
+func getContainerCgroupScopeDirectory(podCgroupSliceDirectory, containerID string) string {
+	containerID = strings.Replace(containerID, "containerd://", "", 1) // assumes only containerd
+	return fmt.Sprintf(
+		"%s/cri-containerd-%s.scope",
+		podCgroupSliceDirectory,
+		containerID,
+	)
+}

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -1,0 +1,176 @@
+package informer
+
+import (
+	"errors"
+	"os"
+	"strconv"
+
+	"github.com/norbjd/k8s-pod-cpu-booster/pkg/cgroup"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/informers/internalinterfaces"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+const (
+	cpuBoostStartupAnnotation = "norbjd.github.io/k8s-pod-cpu-booster-enabled"
+
+	cpuBoostMultiplierAnnotation = "norbjd.github.io/k8s-pod-cpu-booster-multiplier"
+	cpuBoostDefaultMultiplier    = uint64(10)
+)
+
+// Inspired by:
+// - https://www.cncf.io/blog/2019/10/15/extend-kubernetes-via-a-shared-informer/
+func Run(clientset *kubernetes.Clientset, cgroupHandler cgroup.CgroupHandler) {
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, informers.WithTweakListOptions(podCPUBoosterTweakFunc()))
+	informer := factory.Core().V1().Pods().Informer()
+
+	stopper := make(chan struct{})
+	defer close(stopper)
+	defer runtime.HandleCrash()
+
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			onUpdate(cgroupHandler, oldObj, newObj)
+		},
+	})
+
+	go informer.Run(stopper)
+	klog.Infof("Informer started!")
+
+	if !cache.WaitForCacheSync(stopper, informer.HasSynced) {
+		runtime.HandleError(errors.New("timed out waiting for caches to sync"))
+		return
+	}
+
+	<-stopper
+}
+
+// only check pods running on the current node, assumes NODE_NAME contains the name of the node
+func podCPUBoosterTweakFunc() internalinterfaces.TweakListOptionsFunc {
+	return func(opts *metav1.ListOptions) {
+		opts.FieldSelector = "spec.nodeName=" + os.Getenv("NODE_NAME")
+	}
+}
+
+func getBoostMultiplierFromAnnotations(pod *corev1.Pod) uint64 {
+	if boostMultiplierAnnotationValue, ok := pod.Annotations["cpuBoostMultiplierAnnotation"]; ok {
+		boostMultiplierAnnotationValueInt, err := strconv.ParseUint(boostMultiplierAnnotationValue, 10, 64)
+		if err != nil {
+			klog.Errorf("boost multiplier is not a valid value, will take the default %d instead: %s",
+				cpuBoostDefaultMultiplier, err.Error())
+			return cpuBoostDefaultMultiplier
+		}
+
+		return boostMultiplierAnnotationValueInt
+	}
+
+	return cpuBoostDefaultMultiplier
+}
+
+func onUpdate(cgroupHandler cgroup.CgroupHandler, oldObj interface{}, newObj interface{}) {
+	oldPod := oldObj.(*corev1.Pod)
+	newPod := newObj.(*corev1.Pod)
+	klog.Infof(
+		"pod %s/%s updated",
+		oldPod.Namespace, oldPod.Name,
+	)
+
+	if podHasBoostAnnotation(newPod) {
+		if len(newPod.Status.ContainerStatuses) == 0 {
+			klog.Infof("pod %s/%s has no container statuses, skipping...", newPod.Namespace, newPod.Name)
+			return
+		}
+
+		if len(newPod.Spec.Containers) != 1 {
+			klog.Infof("pod %s/%s contains %d containers, skipping...", newPod.Namespace, newPod.Name, len(newPod.Spec.Containers))
+			return
+		}
+
+		podUID := newPod.UID
+		containerID := newPod.Status.ContainerStatuses[0].ContainerID // this is safe to use [0] as we've checked above if we have 1 container
+
+		initialCPULimit := newPod.Spec.Containers[0].Resources.Limits.Cpu()
+		boostMultiplier := getBoostMultiplierFromAnnotations(newPod)
+
+		// once ready, we reset the CPU as the normal limit
+		if podPassedFromNotReadyToReady(oldPod, newPod) {
+			klog.Infof("will reset %s/%s CPU limit to default", newPod.Namespace, newPod.Name)
+			err := resetCPUBoost(cgroupHandler, podUID, containerID, initialCPULimit)
+			if err != nil {
+				klog.Errorf("error while resetting CPU boost: %s", err.Error())
+			}
+		} else { // TODO: do that only once
+			klog.Infof("will boost %s/%s CPU limit", newPod.Namespace, newPod.Name)
+			err := boostCPU(cgroupHandler, podUID, containerID, initialCPULimit, boostMultiplier)
+			if err != nil {
+				klog.Errorf("error while boosting CPU: %s", err.Error())
+			}
+		}
+	}
+}
+
+func podHasBoostAnnotation(pod *corev1.Pod) bool {
+	boost, ok := pod.Annotations[cpuBoostStartupAnnotation]
+	return ok && boost == "true"
+}
+
+func podPassedFromNotReadyToReady(oldPod, newPod *corev1.Pod) bool {
+	podWasNotReady := false
+
+	for _, condition := range oldPod.Status.Conditions {
+		if condition.Type == "Ready" && condition.Status == "False" {
+			podWasNotReady = true
+			break
+		}
+	}
+
+	if podWasNotReady {
+		for _, condition := range newPod.Status.Conditions {
+			if condition.Type == "Ready" && condition.Status == "True" {
+				klog.Infof(
+					"pod %s/%s is now ready",
+					oldPod.Namespace, oldPod.Name,
+				)
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func quantityToCPULimit(quantity *resource.Quantity) uint64 {
+	return uint64(quantity.AsApproximateFloat64() * 100_000.)
+}
+
+func boostCPU(cgroupHandler cgroup.CgroupHandler, podUID types.UID, containerID string, initialCPULimit *resource.Quantity, boostMultiplier uint64) error {
+	klog.Infof("CPU limit: %d", quantityToCPULimit(initialCPULimit))
+	cgroupCPULimitAfterBoost := quantityToCPULimit(initialCPULimit) * boostMultiplier
+	klog.Infof("New cgroup cpu limit to: %d", cgroupCPULimitAfterBoost)
+
+	err := cgroupHandler.WriteCPUMax(podUID, containerID, cgroupCPULimitAfterBoost)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resetCPUBoost(cgroupHandler cgroup.CgroupHandler, podUID types.UID, containerID string, initialCPULimit *resource.Quantity) error {
+	cgroupCPULimitAfterReset := quantityToCPULimit(initialCPULimit)
+	klog.Infof("Reset cgroup cpu limit to: %d", cgroupCPULimitAfterReset)
+
+	err := cgroupHandler.WriteCPUMax(podUID, containerID, cgroupCPULimitAfterReset)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Before, everything was in `main.go`.

Now, we have a better structured code, allowing to define other targets than just KinD.