### PR TITLE
Run e2e tests on k8s 1.28 (but keep 1.27)

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         k8s-version:
         - v1.27.x
+        - v1.28.x
         os:
         - ubuntu-20.04 # Ubuntu 20.04 uses cgroup v1
         - ubuntu-22.04 # Ubuntu 22.04 uses cgroup v2


### PR DESCRIPTION
See title.

I'm doing this as `InPlacePodVerticalScaling` is an alpha feature, so it can evolve quickly between k8s 2 versions (and maybe introduce breaking changes). Checking on k8s 1.27 and 1.28 should catch such regressions.