### PR TITLE
Add tests and examples with deployments

### DIFF
--- a/examples/deployment-with-default-boost.yaml
+++ b/examples/deployment-with-default-boost.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-with-default-boost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deployment-with-default-boost
+  template:
+    metadata:
+      annotations:
+        norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
+      labels:
+        app: deployment-with-default-boost
+    spec:
+      containers:
+      - image: python:3.11-alpine
+        name: python
+        command: ["python"]
+        args:
+        - -m
+        - http.server
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 0
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100M
+          limits:
+            cpu: 50m
+            memory: 100M
+      terminationGracePeriodSeconds: 0

--- a/examples/deployment-with-no-boost.yaml
+++ b/examples/deployment-with-no-boost.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-with-no-boost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deployment-with-no-boost
+  template:
+    metadata:
+      labels:
+        app: deployment-with-no-boost
+    spec:
+      containers:
+      - image: python:3.11-alpine
+        name: python
+        command: ["python"]
+        args:
+        - -m
+        - http.server
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 0
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100M
+          limits:
+            cpu: 50m
+            memory: 100M
+      terminationGracePeriodSeconds: 0

--- a/examples/pod-no-boost.yaml
+++ b/examples/pod-no-boost.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: python-no-boost
+  name: pod-no-boost
 spec:
   containers:
   - image: python:3.11-alpine

--- a/examples/pod-with-default-boost.yaml
+++ b/examples/pod-with-default-boost.yaml
@@ -3,8 +3,7 @@ kind: Pod
 metadata:
   annotations:
     norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
-    norbjd.github.io/k8s-pod-cpu-booster-multiplier: "3"
-  name: python-with-small-boost
+  name: pod-with-default-boost
 spec:
   containers:
   - image: python:3.11-alpine
@@ -20,6 +19,9 @@ spec:
       periodSeconds: 1
       successThreshold: 1
       timeoutSeconds: 1
+    resizePolicy:
+    - resourceName: cpu
+      restartPolicy: NotRequired # this is very important to be able to update the CPU resources in place (no need to restart the pod)
     resources:
       requests:
         cpu: 50m

--- a/examples/pod-with-small-boost.yaml
+++ b/examples/pod-with-small-boost.yaml
@@ -3,7 +3,8 @@ kind: Pod
 metadata:
   annotations:
     norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
-  name: python-with-boost
+    norbjd.github.io/k8s-pod-cpu-booster-multiplier: "3"
+  name: pod-with-small-boost
 spec:
   containers:
   - image: python:3.11-alpine
@@ -19,9 +20,6 @@ spec:
       periodSeconds: 1
       successThreshold: 1
       timeoutSeconds: 1
-    resizePolicy:
-    - resourceName: cpu
-      restartPolicy: NotRequired # this is very important to be able to update the CPU resources in place (no need to restart the pod)
     resources:
       requests:
         cpu: 50m

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -9,42 +9,66 @@ docker pull python:3.11-alpine
 kind load docker-image python:3.11-alpine
 
 kubectl apply \
-    -f ./test/e2e/python-no-boost.yaml \
-    -f ./test/e2e/python-with-boost.yaml
+    -f ./test/e2e/pod-no-boost.yaml \
+    -f ./test/e2e/pod-with-default-boost.yaml \
+    -f ./test/e2e/deployment-no-boost.yaml \
+    -f ./test/e2e/deployment-with-default-boost.yaml
 
-kubectl wait --for=condition=Ready pod/python-with-boost pod/python-no-boost
+kubectl wait --for=condition=Ready pod/pod-with-default-boost pod/pod-no-boost
+kubectl wait --for=condition=Available deployment/deployment-with-default-boost deployment/deployment-no-boost
 
-python_with_boost_start_time=$(kubectl get pods python-with-boost -o go-template='{{ range .status.containerStatuses }}{{ if eq .name "python" }}{{ .state.running.startedAt }}{{ end }}{{ end }}')
-python_with_boost_ready_time=$(kubectl get pods python-with-boost -o go-template='{{ range .status.conditions }}{{ if (and (eq .type "Ready") (eq .status "True")) }}{{ .lastTransitionTime }}{{ end }}{{ end }}')
-python_with_boost_seconds_to_be_ready=$(( $( date -d "$python_with_boost_ready_time" +%s ) - $( date -d "$python_with_boost_start_time" +%s ) ))
-echo "[INFO] python-with-boost pod took $python_with_boost_seconds_to_be_ready second(s) to be ready"
+pod_with_boost_start_time=$(kubectl get pods pod-with-default-boost -o go-template='{{ range .status.containerStatuses }}{{ if eq .name "python" }}{{ .state.running.startedAt }}{{ end }}{{ end }}')
+pod_with_boost_ready_time=$(kubectl get pods pod-with-default-boost -o go-template='{{ range .status.conditions }}{{ if (and (eq .type "Ready") (eq .status "True")) }}{{ .lastTransitionTime }}{{ end }}{{ end }}')
+pod_with_boost_seconds_to_be_ready=$(( $( date -d "$pod_with_boost_ready_time" +%s ) - $( date -d "$pod_with_boost_start_time" +%s ) ))
+echo "[INFO] pod-with-default-boost pod took $pod_with_boost_seconds_to_be_ready second(s) to be ready"
 
-python_no_boost_start_time=$(kubectl get pods python-no-boost -o go-template='{{ range .status.containerStatuses }}{{ if eq .name "python" }}{{ .state.running.startedAt }}{{ end }}{{ end }}')
-python_no_boost_ready_time=$(kubectl get pods python-no-boost -o go-template='{{ range .status.conditions }}{{ if (and (eq .type "Ready") (eq .status "True")) }}{{ .lastTransitionTime }}{{ end }}{{ end }}')
-python_no_boost_seconds_to_be_ready=$(( $( date -d "$python_no_boost_ready_time" +%s ) - $( date -d "$python_no_boost_start_time" +%s ) ))
-echo "[INFO] python-no-boost pod took $python_no_boost_seconds_to_be_ready second(s) to be ready"
+pod_no_boost_start_time=$(kubectl get pods pod-no-boost -o go-template='{{ range .status.containerStatuses }}{{ if eq .name "python" }}{{ .state.running.startedAt }}{{ end }}{{ end }}')
+pod_no_boost_ready_time=$(kubectl get pods pod-no-boost -o go-template='{{ range .status.conditions }}{{ if (and (eq .type "Ready") (eq .status "True")) }}{{ .lastTransitionTime }}{{ end }}{{ end }}')
+pod_no_boost_seconds_to_be_ready=$(( $( date -d "$pod_no_boost_ready_time" +%s ) - $( date -d "$pod_no_boost_start_time" +%s ) ))
+echo "[INFO] pod-no-boost pod took $pod_no_boost_seconds_to_be_ready second(s) to be ready"
+
+# for pods managed by a deployment, the following kubectl commands work because we have only 1 replica
+deployment_with_boost_pod_start_time=$(kubectl get pods -l app=deployment-with-default-boost -o go-template='{{ range (index .items 0).status.containerStatuses }}{{ if eq .name "python" }}{{ .state.running.startedAt }}{{ end }}{{ end }}')
+deployment_with_boost_pod_ready_time=$(kubectl get pods -l app=deployment-with-default-boost -o go-template='{{ range (index .items 0).status.conditions }}{{ if (and (eq .type "Ready") (eq .status "True")) }}{{ .lastTransitionTime }}{{ end }}{{ end }}')
+deployment_with_boost_pod_seconds_to_be_ready=$(( $( date -d "$deployment_with_boost_pod_ready_time" +%s ) - $( date -d "$deployment_with_boost_pod_start_time" +%s ) ))
+echo "[INFO] pod from deployment-with-default-boost deployment took $deployment_with_boost_pod_seconds_to_be_ready second(s) to be ready"
+
+deployment_no_boost_pod_start_time=$(kubectl get pods -l app=deployment-no-boost -o go-template='{{ range (index .items 0).status.containerStatuses }}{{ if eq .name "python" }}{{ .state.running.startedAt }}{{ end }}{{ end }}')
+deployment_no_boost_pod_ready_time=$(kubectl get pods -l app=deployment-no-boost -o go-template='{{ range (index .items 0).status.conditions }}{{ if (and (eq .type "Ready") (eq .status "True")) }}{{ .lastTransitionTime }}{{ end }}{{ end }}')
+deployment_no_boost_pod_seconds_to_be_ready=$(( $( date -d "$deployment_no_boost_pod_ready_time" +%s ) - $( date -d "$deployment_no_boost_pod_start_time" +%s ) ))
+echo "[INFO] pod from deployment-no-boost deployment took $deployment_no_boost_pod_seconds_to_be_ready second(s) to be ready"
 
 exit_code=0
 
-# python-with-boost should start <ready_time_minimum_ratio> times quicker than python-no-boost
+# pods with default boosts should start <ready_time_minimum_ratio> times quicker than pods with no boost
 ready_time_minimum_ratio=2
 
-if [ $(( $python_no_boost_seconds_to_be_ready / $python_with_boost_seconds_to_be_ready )) -ge $ready_time_minimum_ratio ]
+if [ $(( $pod_no_boost_seconds_to_be_ready / $pod_with_boost_seconds_to_be_ready )) -ge $ready_time_minimum_ratio ]
 then
-    echo -e "\033[0;32m[SUCCESS]\033[0m python-with-boost started more than $ready_time_minimum_ratio times quicker than python-no-boost"
+    echo -e "\033[0;32m[SUCCESS]\033[0m pod-with-default-boost started more than $ready_time_minimum_ratio times quicker than pod-no-boost"
 else
-    echo -e "\033[0;31m[FAILURE]\033[0m python-with-boost should start more than $ready_time_minimum_ratio times quicker than python-no-boost"
+    echo -e "\033[0;31m[FAILURE]\033[0m pod-with-default-boost should start more than $ready_time_minimum_ratio times quicker than pod-no-boost"
+    exit_code=1
+fi
+
+if [ $(( $deployment_no_boost_pod_seconds_to_be_ready / $deployment_with_boost_pod_seconds_to_be_ready )) -ge $ready_time_minimum_ratio ]
+then
+    echo -e "\033[0;32m[SUCCESS]\033[0m pods managed by deployment-with-default-boost started more than $ready_time_minimum_ratio times quicker than pods managed by deployment-no-boost"
+else
+    echo -e "\033[0;31m[FAILURE]\033[0m pods managed by deployment-with-default-boost should start more than $ready_time_minimum_ratio times quicker than pods managed by deployment-no-boost"
     exit_code=1
 fi
 
 # also check that cgroup cpu.max or cpu.cfs_quota_us file is back to the default limits
-python_with_boost_pod_uid=$(kubectl get pods python-with-boost -o jsonpath='{.metadata.uid}' | sed 's~-~_~g')
-python_with_boost_python_container_id=$(kubectl get pods python-with-boost -o jsonpath='{.status.containerStatuses[?(@.name=="python")].containerID}' | cut -d '/' -f 3)
+pod_with_boost_pod_uid=$(kubectl get pods pod-with-default-boost -o jsonpath='{.metadata.uid}' | sed 's~-~_~g')
+pod_with_boost_python_container_id=$(kubectl get pods pod-with-default-boost -o jsonpath='{.status.containerStatuses[?(@.name=="python")].containerID}' | cut -d '/' -f 3)
+deployment_with_boost_pod_uid=$(kubectl get pods -l app=deployment-with-default-boost -o jsonpath='{.items[0].metadata.uid}' | sed 's~-~_~g')
+deployment_with_boost_pod_python_container_id=$(kubectl get pods -l app=deployment-with-default-boost -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="python")].containerID}' | cut -d '/' -f 3)
 
 if [ "$OS" == "ubuntu-20.04" ] # cgroup v1
 then
-    docker exec kind-worker cat /sys/fs/cgroup/cpu,cpuacct/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cpu.cfs_quota_us > pod_cpu.cfs_quota_us
-    docker exec kind-worker cat /sys/fs/cgroup/cpu,cpuacct/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cri-containerd-${python_with_boost_python_container_id}.scope/cpu.cfs_quota_us > python_container_cpu.cfs_quota_us
+    docker exec kind-worker cat /sys/fs/cgroup/cpu,cpuacct/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${pod_with_boost_pod_uid}.slice/cpu.cfs_quota_us > pod_cpu.cfs_quota_us
+    docker exec kind-worker cat /sys/fs/cgroup/cpu,cpuacct/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${pod_with_boost_pod_uid}.slice/cri-containerd-${pod_with_boost_python_container_id}.scope/cpu.cfs_quota_us > pod_container_cpu.cfs_quota_us
 
     if ! diff -b <(cat pod_cpu.cfs_quota_us) <(echo "5000")
     then
@@ -52,14 +76,29 @@ then
         exit_code=1
     fi
 
-    if ! diff -b <(cat python_container_cpu.cfs_quota_us) <(echo "5000")
+    if ! diff -b <(cat pod_container_cpu.cfs_quota_us) <(echo "5000")
     then
         echo -e "\033[0;31m[FAILURE]\033[0m python container cgroup cpu.cfs_quota_us has not been reset"
         exit_code=1
     fi
+
+    docker exec kind-worker cat /sys/fs/cgroup/cpu,cpuacct/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${deployment_with_boost_pod_uid}.slice/cpu.cfs_quota_us > deployment_pod_cpu.cfs_quota_us
+    docker exec kind-worker cat /sys/fs/cgroup/cpu,cpuacct/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${deployment_with_boost_pod_uid}.slice/cri-containerd-${deployment_with_boost_pod_python_container_id}.scope/cpu.cfs_quota_us > deployment_pod_container_cpu.cfs_quota_us
+
+    if ! diff -b <(cat deployment_pod_cpu.cfs_quota_us) <(echo "5000")
+    then
+        echo -e "\033[0;31m[FAILURE]\033[0m pod (managed by deployment) cgroup cpu.cfs_quota_us has not been reset"
+        exit_code=1
+    fi
+
+    if ! diff -b <(cat deployment_pod_container_cpu.cfs_quota_us) <(echo "5000")
+    then
+        echo -e "\033[0;31m[FAILURE]\033[0m python container (in pod managed by deployment) cgroup cpu.cfs_quota_us has not been reset"
+        exit_code=1
+    fi
 else # cgroup v2
-    docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cpu.max > pod_cpu.max
-    docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${python_with_boost_pod_uid}.slice/cri-containerd-${python_with_boost_python_container_id}.scope/cpu.max > python_container_cpu.max
+    docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${pod_with_boost_pod_uid}.slice/cpu.max > pod_cpu.max
+    docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${pod_with_boost_pod_uid}.slice/cri-containerd-${pod_with_boost_python_container_id}.scope/cpu.max > pod_container_cpu.max
 
     if ! diff -b <(cat pod_cpu.max) <(echo "5000 100000")
     then
@@ -67,9 +106,24 @@ else # cgroup v2
         exit_code=1
     fi
 
-    if ! diff -b <(cat python_container_cpu.max) <(echo "5000 100000")
+    if ! diff -b <(cat pod_container_cpu.max) <(echo "5000 100000")
     then
         echo -e "\033[0;31m[FAILURE]\033[0m python container cgroup cpu.max has not been reset"
+        exit_code=1
+    fi
+
+    docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${deployment_with_boost_pod_uid}.slice/cpu.max > deployment_pod_cpu.max
+    docker exec kind-worker cat /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-pod${deployment_with_boost_pod_uid}.slice/cri-containerd-${deployment_with_boost_pod_python_container_id}.scope/cpu.max > deployment_pod_container_cpu.max
+
+    if ! diff -b <(cat deployment_pod_cpu.max) <(echo "5000 100000")
+    then
+        echo -e "\033[0;31m[FAILURE]\033[0m pod (managed by deployment) cgroup cpu.max has not been reset"
+        exit_code=1
+    fi
+
+    if ! diff -b <(cat deployment_pod_container_cpu.max) <(echo "5000 100000")
+    then
+        echo -e "\033[0;31m[FAILURE]\033[0m python container (in pod managed by deployment) cgroup cpu.max has not been reset"
         exit_code=1
     fi
 fi
@@ -80,7 +134,9 @@ kubectl logs --tail=-1 -n pod-cpu-booster -l name=pod-cpu-booster
 echo "===================="
 
 kubectl delete \
-    -f ./test/e2e/python-no-boost.yaml \
-    -f ./test/e2e/python-with-boost.yaml
+    -f ./test/e2e/pod-no-boost.yaml \
+    -f ./test/e2e/pod-with-default-boost.yaml \
+    -f ./test/e2e/deployment-no-boost.yaml \
+    -f ./test/e2e/deployment-with-default-boost.yaml
 
 exit $exit_code

--- a/test/e2e/deployment-no-boost.yaml
+++ b/test/e2e/deployment-no-boost.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-no-boost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deployment-no-boost
+  template:
+    metadata:
+      labels:
+        app: deployment-no-boost
+    spec:
+      containers:
+      - image: python:3.11-alpine
+        name: python
+        command: ["python"]
+        args:
+        - -m
+        - http.server
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 0
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100M
+          limits:
+            cpu: 50m
+            memory: 100M
+      terminationGracePeriodSeconds: 0

--- a/test/e2e/deployment-with-default-boost.yaml
+++ b/test/e2e/deployment-with-default-boost.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-with-default-boost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deployment-with-default-boost
+  template:
+    metadata:
+      annotations:
+        norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
+      labels:
+        app: deployment-with-default-boost
+    spec:
+      containers:
+      - image: python:3.11-alpine
+        name: python
+        command: ["python"]
+        args:
+        - -m
+        - http.server
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 0
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        resizePolicy:
+        - resourceName: cpu
+          restartPolicy: NotRequired
+        resources:
+          requests:
+            cpu: 50m
+            memory: 100M
+          limits:
+            cpu: 50m
+            memory: 100M
+      terminationGracePeriodSeconds: 0

--- a/test/e2e/pod-no-boost.yaml
+++ b/test/e2e/pod-no-boost.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: python-no-boost
+  name: pod-no-boost
 spec:
   containers:
   - image: python:3.11-alpine

--- a/test/e2e/pod-with-default-boost.yaml
+++ b/test/e2e/pod-with-default-boost.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   annotations:
     norbjd.github.io/k8s-pod-cpu-booster-enabled: "true"
-  name: python-with-default-boost
+  name: pod-with-default-boost
 spec:
   containers:
   - image: python:3.11-alpine


### PR DESCRIPTION
The k8s-pod-cpu-booster does not just work with raw `Pod`s, but also with `Deployment`s (or any other resources managing `Pod`s I believe).

This adds some examples and e2e tests to validate it works with `Deployment`s.

I've also renamed existing files named `python-xxx` with `pod-xxx`. This is just to visually differentiate files related to pods (`pods-xxx`) and files related to deployments (`deployment-xxx`).