### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple PoC to give pods a CPU boost during startup (before pod is `Ready`).
 
 :warning: **this is pre-alpha / work in progress, don't use in production** :warning:
 
-- supports Kubernetes clusters starting from version 1.27 only (for older versions, see [`v0.1.0`](https://github.com/norbjd/k8s-pod-cpu-booster/tree/v0.1.0) tag)
+- supports Kubernetes clusters starting from version 1.27 only (for older versions, see [`v0.1.0`](https://github.com/norbjd/k8s-pod-cpu-booster/tree/v0.1.0))
 - requires pods to have a `readinessProbe` configured, and a value for `resources.limits.cpu`
 - only works with pods with a single container
 


### PR DESCRIPTION
- remove references to cgroups tweaking
- now we support all clusters (starting from version 1.27)