### PR TITLE
Add Kubernetes 1.29.x in test matrix

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -21,6 +21,7 @@ jobs:
         k8s-version:
         - v1.27.x
         - v1.28.x
+        - v1.29.x
         os:
         # - ubuntu-20.04 # Ubuntu 20.04 uses cgroup v1 # TODO: temporarily disabled because of openssl commands incompatibility (1.1.1 version vs 3.x)
         - ubuntu-22.04 # Ubuntu 22.04 uses cgroup v2

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -43,6 +43,10 @@ exit_code=0
 # pods with default boosts should start <ready_time_minimum_ratio> times quicker than pods with no boost
 ready_time_minimum_ratio=2
 
+# avoid divisions by zero by adding 1 second, shouldn't affect the result
+pod_with_boost_seconds_to_be_ready=$(($pod_with_boost_seconds_to_be_ready + 1))
+deployment_with_boost_pod_seconds_to_be_ready=$(($deployment_with_boost_pod_seconds_to_be_ready + 1))
+
 if [ $(( $pod_no_boost_seconds_to_be_ready / $pod_with_boost_seconds_to_be_ready )) -ge $ready_time_minimum_ratio ]
 then
     echo -e "\033[0;32m[SUCCESS]\033[0m pod-with-default-boost started more than $ready_time_minimum_ratio times quicker than pod-no-boost"


### PR DESCRIPTION
Fixes #22.

Also fixes a flaky e2e test (when pod takes < 1 second to start, test will try to divide by zero: https://github.com/norbjd/k8s-pod-cpu-booster/actions/runs/8316283069/job/22755561778#step:8:44). So we will add 1 to avoid it. Adding a second won't really affect the result.

```
[INFO] pod-with-default-boost pod took 0 second(s) to be ready
[INFO] pod-no-boost pod took 7 second(s) to be ready
[INFO] pod from deployment-with-default-boost deployment took 0 second(s) to be ready
[INFO] pod from deployment-no-boost deployment took 7 second(s) to be ready
./test/e2e-kind.sh: line 46: 7 / 0 : division by 0 (error token is "0 ")
./test/e2e-kind.sh: line 48: 7 / 0 : division by 0 (error token is "0 ")
```

This is a temporary fix until #17 is solved.