### PR TITLE
Add a pre-install Helm hook to ensure InPlacePodVerticalScaling is enabled

### DIFF
--- a/helm/templates/pre-install-hook-check-feature-gate.yaml
+++ b/helm/templates/pre-install-hook-check-feature-gate.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: check-in-place-pod-vertical-scaling-enabled
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: get-kubernetes-metrics
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - nonResourceURLs:
+    - "/metrics"
+    verbs:
+    - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: check-in-place-pod-vertical-scaling-enabled
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: get-kubernetes-metrics
+subjects:
+  - kind: ServiceAccount
+    name: check-in-place-pod-vertical-scaling-enabled
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: check-in-place-pod-vertical-scaling-enabled
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  serviceAccountName: check-in-place-pod-vertical-scaling-enabled
+  restartPolicy: Never
+  containers:
+    - name: check-in-place-pod-vertical-scaling-enabled
+      image: "bitnami/kubectl"
+      command:
+        - sh
+        - -c
+        - |
+          if ! kubectl get --raw /metrics | grep -q -E '^kubernetes_feature_enabled.*name="InPlacePodVerticalScaling".*1$'
+          then
+            printf "InPlacePodVerticalScaling feature gate is required to install this chart, see README." | tee /dev/termination-log
+            exit 1
+          fi
+
+          printf "InPlacePodVerticalScaling feature gate is enabled; will continue!" | tee /dev/termination-log
+      terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
This check is useful to avoid installing the chart if it won't work anyways (if `InPlacePodVerticalScaling` is disabled).

As of today, if the hook fails, Helm will not return the error message thrown by the pod: https://github.com/helm/helm/issues/3370. But, in case of failure, the pod will stay in the cluster, so users can debug by themselves by checking the pod logs :shrug: