### PR TITLE
Run multiple replicas of the informer

### DIFF
--- a/cmd/informer/main.go
+++ b/cmd/informer/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"context"
 	"flag"
 
 	"github.com/norbjd/k8s-pod-cpu-booster/pkg/informer"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -12,7 +12,26 @@ import (
 
 func main() {
 	klog.InitFlags(nil)
+
+	var id string
+	var leaseLockNamespace string
+	var leaseLockName string
+
+	flag.StringVar(&id, "id", "", "the lease lock resource name")
+	flag.StringVar(&leaseLockNamespace, "lease-lock-namespace", "", "the lease lock resource namespace")
+	flag.StringVar(&leaseLockName, "lease-lock-name", "", "path to key file")
+
 	flag.Parse()
+
+	if id == "" {
+		klog.Fatal("lease holder identity is required (missing id flag)")
+	}
+	if leaseLockNamespace == "" {
+		klog.Fatal("unable to get lease lock resource namespace (missing lease-lock-namespace flag)")
+	}
+	if leaseLockName == "" {
+		klog.Fatal("unable to get lease lock resource name (missing lease-lock-name flag)")
+	}
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -24,5 +43,8 @@ func main() {
 		panic(err)
 	}
 
-	informer.Run(clientset)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	informer.Run(ctx, clientset, id, leaseLockNamespace, leaseLockName)
 }

--- a/helm/templates/pod-cpu-boost-reset.yaml
+++ b/helm/templates/pod-cpu-boost-reset.yaml
@@ -1,4 +1,9 @@
 ---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: pod-cpu-boost-reset
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -32,12 +37,40 @@ subjects:
     name: pod-cpu-boost-reset
     namespace: {{ .Release.Namespace }}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: acquire-lease
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - pod-cpu-boost-reset
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-cpu-boost-reset
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: acquire-lease
+subjects:
+  - kind: ServiceAccount
+    name: pod-cpu-boost-reset
+    namespace: {{ .Release.Namespace }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pod-cpu-boost-reset
 spec:
-  replicas: 1 # for now, we don't support multiple replicas
+  replicas: 3
   selector:
     matchLabels:
       app: pod-cpu-boost-reset
@@ -49,6 +82,15 @@ spec:
       containers:
       - name: pod-cpu-boost-reset
         image: {{ .Values.informer.image }}
+        args:
+        - --id=$(POD_NAME)
+        - --lease-lock-namespace={{ .Release.Namespace }}
+        - --lease-lock-name=pod-cpu-boost-reset
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         imagePullPolicy: {{ .Values.informer.imagePullPolicy }}
         resources:
           {{ toYaml .Values.resources }}


### PR DESCRIPTION
Before, it was only possible to run 1 replica of the informer because there could be some race conditions.

This PR adds a coordination lease used by all informers, so it's possible to define multiple replicas. Only one replica will be the leader, but if it goes down, at least another one should take the lead.

The lease logic is based on this example: https://github.com/kubernetes/client-go/blob/v0.29.3/examples/leader-election/main.go.