### PR TITLE
Helm chart: add informer.replicaCount, and default all replicaCount values to 1

### DIFF
--- a/helm/templates/pod-cpu-boost-reset.yaml
+++ b/helm/templates/pod-cpu-boost-reset.yaml
@@ -70,7 +70,7 @@ kind: Deployment
 metadata:
   name: pod-cpu-boost-reset
 spec:
-  replicas: 3
+  replicas: {{ .Values.informer.replicaCount }}
   selector:
     matchLabels:
       app: pod-cpu-boost-reset

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,10 +5,11 @@ fullnameOverride: ""
 informer:
   image: ghcr.io/norbjd/k8s-pod-cpu-booster/informer:main
   imagePullPolicy: Always
+  replicaCount: 1
   resources: {}
 
 webhook:
   image: ghcr.io/norbjd/k8s-pod-cpu-booster/webhook:main
   imagePullPolicy: Always
-  replicaCount: 3
+  replicaCount: 1
   resources: {}


### PR DESCRIPTION
By default, no need to put more than 1 replicas. But let this be configurable through Helm values.