### PR TITLE
Add SLSA generator

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,76 +1,77 @@
-name: KinD e2e tests
-
-on:
-  pull_request:
-    branches:
-    - main
-  push:
-    branches:
-    - main
-
-defaults:
-  run:
-    shell: bash
-
-jobs:
-  e2e-tests:
-    name: e2e tests
-    strategy:
-      fail-fast: false
-      matrix:
-        k8s-version:
-        - v1.27.x
-        - v1.28.x
-        - v1.29.x
-        os:
-        - ubuntu-20.04 # Ubuntu 20.04 uses cgroup v1
-        - ubuntu-22.04 # Ubuntu 22.04 uses cgroup v2
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - name: Set up Go 1.21.x
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.21.x
-
-    - uses: ko-build/setup-ko@v0.6
-
-    - name: Check out code
-      uses: actions/checkout@v4
-
-    - name: Setup KinD
-      # TODO: this is a fork to be able to use feature gates
-      # TODO: change to the official chainguard-dev/actions/setup-kind@main when merged upstream
-      uses: norbjd/actions/setup-kind@add-feature-gates-to-setup-kind
-      with:
-        k8s-version: ${{ matrix.k8s-version }}
-        kind-worker-count: 1
-        feature-gates: InPlacePodVerticalScaling
-
-    - name: Install helm
-      run: |
-        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-    - name: Install k8s-pod-cpu-booster
-      env:
-        KO_DOCKER_REPO: kind.local
-      run: |
-        INFORMER_IMAGE=$(ko build ./cmd/informer)
-        WEBHOOK_IMAGE=$(ko build ./cmd/webhook)
-
-        helm install k8s-pod-cpu-booster --namespace pod-cpu-booster --create-namespace ./charts/k8s-pod-cpu-booster \
-          --set informer.image=$INFORMER_IMAGE \
-          --set informer.imagePullPolicy=Never \
-          --set webhook.image=$WEBHOOK_IMAGE \
-          --set webhook.imagePullPolicy=Never
-
-    - name: Wait for Ready
-      run: |
-        echo "Waiting for k8s-pod-cpu-booster items to become ready"
-        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=pod-cpu-boost-reset
-        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=mutating-webhook
-        sleep 5 # because readiness probe is not accurate (Ready != informer is started), but sleeping is enough for now
-
-    - name: Run e2e Tests
-      run: |
-        OS=${{ matrix.os }} ./test/e2e-kind.sh
+#name: KinD e2e tests
+#
+#on:
+#  pull_request:
+#    branches:
+#    - main
+#  push:
+#    branches:
+#    - main
+#
+#defaults:
+#  run:
+#    shell: bash
+#
+#jobs:
+#  e2e-tests:
+#    name: e2e tests
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        k8s-version:
+#        - v1.27.x
+#        - v1.28.x
+#        - v1.29.x
+#        os:
+#        - ubuntu-20.04 # Ubuntu 20.04 uses cgroup v1
+#        - ubuntu-22.04 # Ubuntu 22.04 uses cgroup v2
+#    runs-on: ${{ matrix.os }}
+#
+#    steps:
+#    - name: Set up Go 1.21.x
+#      uses: actions/setup-go@v4
+#      with:
+#        go-version: 1.21.x
+#
+#    - uses: ko-build/setup-ko@v0.6
+#
+#    - name: Check out code
+#      uses: actions/checkout@v4
+#
+#    - name: Setup KinD
+#      # TODO: this is a fork to be able to use feature gates
+#      # TODO: change to the official chainguard-dev/actions/setup-kind@main when merged upstream
+#      uses: norbjd/actions/setup-kind@add-feature-gates-to-setup-kind
+#      with:
+#        k8s-version: ${{ matrix.k8s-version }}
+#        kind-worker-count: 1
+#        feature-gates: InPlacePodVerticalScaling
+#
+#    - name: Install helm
+#      run: |
+#        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+#
+#    - name: Install k8s-pod-cpu-booster
+#      env:
+#        KO_DOCKER_REPO: kind.local
+#      run: |
+#        INFORMER_IMAGE=$(ko build ./cmd/informer)
+#        WEBHOOK_IMAGE=$(ko build ./cmd/webhook)
+#
+#        helm install k8s-pod-cpu-booster --namespace pod-cpu-booster --create-namespace ./charts/k8s-pod-cpu-booster \
+#          --set informer.image=$INFORMER_IMAGE \
+#          --set informer.imagePullPolicy=Never \
+#          --set webhook.image=$WEBHOOK_IMAGE \
+#          --set webhook.imagePullPolicy=Never
+#
+#    - name: Wait for Ready
+#      run: |
+#        echo "Waiting for k8s-pod-cpu-booster items to become ready"
+#        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=pod-cpu-boost-reset
+#        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=mutating-webhook
+#        sleep 5 # because readiness probe is not accurate (Ready != informer is started), but sleeping is enough for now
+#
+#    - name: Run e2e Tests
+#      run: |
+#        OS=${{ matrix.os }} ./test/e2e-kind.sh
+#

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,77 +1,76 @@
-#name: KinD e2e tests
-#
-#on:
-#  pull_request:
-#    branches:
-#    - main
-#  push:
-#    branches:
-#    - main
-#
-#defaults:
-#  run:
-#    shell: bash
-#
-#jobs:
-#  e2e-tests:
-#    name: e2e tests
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        k8s-version:
-#        - v1.27.x
-#        - v1.28.x
-#        - v1.29.x
-#        os:
-#        - ubuntu-20.04 # Ubuntu 20.04 uses cgroup v1
-#        - ubuntu-22.04 # Ubuntu 22.04 uses cgroup v2
-#    runs-on: ${{ matrix.os }}
-#
-#    steps:
-#    - name: Set up Go 1.21.x
-#      uses: actions/setup-go@v4
-#      with:
-#        go-version: 1.21.x
-#
-#    - uses: ko-build/setup-ko@v0.6
-#
-#    - name: Check out code
-#      uses: actions/checkout@v4
-#
-#    - name: Setup KinD
-#      # TODO: this is a fork to be able to use feature gates
-#      # TODO: change to the official chainguard-dev/actions/setup-kind@main when merged upstream
-#      uses: norbjd/actions/setup-kind@add-feature-gates-to-setup-kind
-#      with:
-#        k8s-version: ${{ matrix.k8s-version }}
-#        kind-worker-count: 1
-#        feature-gates: InPlacePodVerticalScaling
-#
-#    - name: Install helm
-#      run: |
-#        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-#
-#    - name: Install k8s-pod-cpu-booster
-#      env:
-#        KO_DOCKER_REPO: kind.local
-#      run: |
-#        INFORMER_IMAGE=$(ko build ./cmd/informer)
-#        WEBHOOK_IMAGE=$(ko build ./cmd/webhook)
-#
-#        helm install k8s-pod-cpu-booster --namespace pod-cpu-booster --create-namespace ./charts/k8s-pod-cpu-booster \
-#          --set informer.image=$INFORMER_IMAGE \
-#          --set informer.imagePullPolicy=Never \
-#          --set webhook.image=$WEBHOOK_IMAGE \
-#          --set webhook.imagePullPolicy=Never
-#
-#    - name: Wait for Ready
-#      run: |
-#        echo "Waiting for k8s-pod-cpu-booster items to become ready"
-#        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=pod-cpu-boost-reset
-#        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=mutating-webhook
-#        sleep 5 # because readiness probe is not accurate (Ready != informer is started), but sleeping is enough for now
-#
-#    - name: Run e2e Tests
-#      run: |
-#        OS=${{ matrix.os }} ./test/e2e-kind.sh
-#
+name: KinD e2e tests
+
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  e2e-tests:
+    name: e2e tests
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+        - v1.27.x
+        - v1.28.x
+        - v1.29.x
+        os:
+        - ubuntu-20.04 # Ubuntu 20.04 uses cgroup v1
+        - ubuntu-22.04 # Ubuntu 22.04 uses cgroup v2
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Set up Go 1.21.x
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.21.x
+
+    - uses: ko-build/setup-ko@v0.6
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Setup KinD
+      # TODO: this is a fork to be able to use feature gates
+      # TODO: change to the official chainguard-dev/actions/setup-kind@main when merged upstream
+      uses: norbjd/actions/setup-kind@add-feature-gates-to-setup-kind
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+        kind-worker-count: 1
+        feature-gates: InPlacePodVerticalScaling
+
+    - name: Install helm
+      run: |
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    - name: Install k8s-pod-cpu-booster
+      env:
+        KO_DOCKER_REPO: kind.local
+      run: |
+        INFORMER_IMAGE=$(ko build ./cmd/informer)
+        WEBHOOK_IMAGE=$(ko build ./cmd/webhook)
+
+        helm install k8s-pod-cpu-booster --namespace pod-cpu-booster --create-namespace ./charts/k8s-pod-cpu-booster \
+          --set informer.image=$INFORMER_IMAGE \
+          --set informer.imagePullPolicy=Never \
+          --set webhook.image=$WEBHOOK_IMAGE \
+          --set webhook.imagePullPolicy=Never
+
+    - name: Wait for Ready
+      run: |
+        echo "Waiting for k8s-pod-cpu-booster items to become ready"
+        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=pod-cpu-boost-reset
+        kubectl wait pod --for=condition=Ready -n pod-cpu-booster -l app=mutating-webhook
+        sleep 5 # because readiness probe is not accurate (Ready != informer is started), but sleeping is enough for now
+
+    - name: Run e2e Tests
+      run: |
+        OS=${{ matrix.os }} ./test/e2e-kind.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,31 @@
 name: Release
 
 on:
+  pull_request:
+    branches:
+    - main
   push:
     branches:
     - main
 
 jobs:
   release-container-images:
+    id: release-container-images
     name: build and push to ghcr.io
+    strategy:
+      matrix:
+        component:
+        - informer
+        - webhook
     runs-on: ubuntu-22.04
     permissions:
       packages: write
+
+    outputs:
+      informer_image: ${{ steps.release.outputs.informer_image }}
+      informer_digest: ${{ steps.release.outputs.informer_digest }}
+      webhook_image: ${{ steps.release.outputs.webhook_image }}
+      webhook_digest: ${{ steps.release.outputs.webhook_digest }}
 
     steps:
     - uses: actions/setup-go@v4
@@ -19,39 +34,67 @@ jobs:
     - uses: ko-build/setup-ko@v0.6
     - uses: actions/checkout@v4
 
-    - name: Build and push
+    - id: release
+      name: Build and push
       env:
         KO_DOCKER_REPO: ghcr.io/norbjd/k8s-pod-cpu-booster
       run: |
         # something like 202403241909-abcdef01 if we want to use a specific version
         UNIQUE_TAG="$(TZ=UTC0 git log -1 --format=%cd --date=format-local:%Y%m%d%H%M)-$(git rev-parse --short HEAD)"
 
-        ko build ./cmd/informer ./cmd/webhook \
+        ko build ./cmd/{{ matrix.component }} \
           --base-import-paths \
-          --sbom=none \
+          --image-refs=.digest \
           --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
 
-  release-helm-chart:
-    name: release helm chart
-    runs-on: ubuntu-latest
+        image=$(cat .digest | cut -d'@' -f1 | cut -d':' -f1)
+        digest=$(cat .digest| cut -d'@' -f2)
+        echo "{{ matrix.component }}_image=$image" >> "$GITHUB_OUTPUT"
+        echo "{{ matrix.component }}_digest=$digest" >> "$GITHUB_OUTPUT"
+  
+  # see https://github.com/slsa-framework/slsa-github-generator/blob/v1.10.0/internal/builders/container/README.md#ko
+  provenance:
+    needs:
+      - release-container-images
+    strategy:
+      matrix:
+        component:
+        - informer
+        - webhook
     permissions:
-      contents: write
-    
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+    with:
+      image: "${{ needs.release-container-images.outputs[format('{0}_image', matrix.component)] }}"
+      digest: "${{ needs.release-container-images.outputs[format('{0}_digest', matrix.component)] }}"
+      registry-username: ${{ github.actor }}
+      compile-generator: true
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install helm
-        run: |
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  #release-helm-chart:
+  #  name: release helm chart
+  #  runs-on: ubuntu-latest
+  #  permissions:
+  #    contents: write
+  #  
+  #  steps:
+  #    - uses: actions/checkout@v4
+  #      with:
+  #        fetch-depth: 0
+  #
+  #    - name: Configure Git
+  #      run: |
+  #        git config user.name "$GITHUB_ACTOR"
+  #        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #
+  #    - name: Install helm
+  #      run: |
+  #        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+  #
+  #    - name: Run chart-releaser
+  #      uses: helm/chart-releaser-action@v1.6.0
+  #      env:
+  #        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,7 @@ jobs:
 
         ko build ./cmd/${{ matrix.component }} \
           --base-import-paths \
+          --sbom=none \
           --image-refs=.digest \
           --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,16 +80,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-  
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-  
+
       - name: Install helm
         run: |
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-  
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   release-container-images:
-    id: release-container-images
     name: build and push to ghcr.io
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    branches:
-    - main
   push:
     branches:
     - main
@@ -44,7 +41,7 @@ jobs:
         ko build ./cmd/${{ matrix.component }} \
           --base-import-paths \
           --image-refs=.digest \
-          --tags=$UNIQUE_TAG # --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
+          --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
 
         image=$(cat .digest | cut -d'@' -f1 | cut -d':' -f1)
         digest=$(cat .digest| cut -d'@' -f2)
@@ -73,27 +70,27 @@ jobs:
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
 
-  #release-helm-chart:
-  #  name: release helm chart
-  #  runs-on: ubuntu-latest
-  #  permissions:
-  #    contents: write
-  #  
-  #  steps:
-  #    - uses: actions/checkout@v4
-  #      with:
-  #        fetch-depth: 0
-  #
-  #    - name: Configure Git
-  #      run: |
-  #        git config user.name "$GITHUB_ACTOR"
-  #        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-  #
-  #    - name: Install helm
-  #      run: |
-  #        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-  #
-  #    - name: Run chart-releaser
-  #      uses: helm/chart-releaser-action@v1.6.0
-  #      env:
-  #        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  release-helm-chart:
+    name: release helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+  
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  
+      - name: Install helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+  
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
         ko build ./cmd/${{ matrix.component }} \
           --base-import-paths \
           --image-refs=.digest \
-          --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
+          --tags=$UNIQUE_TAG # --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
 
         image=$(cat .digest | cut -d'@' -f1 | cut -d':' -f1)
         digest=$(cat .digest| cut -d'@' -f2)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,15 +41,15 @@ jobs:
         # something like 202403241909-abcdef01 if we want to use a specific version
         UNIQUE_TAG="$(TZ=UTC0 git log -1 --format=%cd --date=format-local:%Y%m%d%H%M)-$(git rev-parse --short HEAD)"
 
-        ko build ./cmd/{{ matrix.component }} \
+        ko build ./cmd/${{ matrix.component }} \
           --base-import-paths \
           --image-refs=.digest \
           --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
 
         image=$(cat .digest | cut -d'@' -f1 | cut -d':' -f1)
         digest=$(cat .digest| cut -d'@' -f2)
-        echo "{{ matrix.component }}_image=$image" >> "$GITHUB_OUTPUT"
-        echo "{{ matrix.component }}_digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "${{ matrix.component }}_image=$image" >> "$GITHUB_OUTPUT"
+        echo "${{ matrix.component }}_digest=$digest" >> "$GITHUB_OUTPUT"
   
   # see https://github.com/slsa-framework/slsa-github-generator/blob/v1.10.0/internal/builders/container/README.md#ko
   provenance:


### PR DESCRIPTION
Add SLSA generator to generate an attestation (`.att` manifest pushed in ghcr, matching the image digest):

![image](https://github.com/norbjd/k8s-pod-cpu-booster/assets/26850303/51ef61a4-9b2e-44d6-bbd3-3bc2c6ddab7f)

To verify image provenance:

```shell
go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.4.1
go install github.com/google/go-containerregistry/cmd/crane@v0.19.1

IMAGE=ghcr.io/norbjd/k8s-pod-cpu-booster/webhook:202403261225-52a8efb
IMAGE="${IMAGE}@"$(crane digest "${IMAGE}")

slsa-verifier verify-image "$IMAGE" --source-uri github.com/norbjd/k8s-pod-cpu-booster
```

Result:

```
Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v1.10.0" at commit 52a8efb0b53332260ac22c48ae8188fbb1e63219
PASSED: Verified SLSA provenance
```