### PR TITLE
Sign SBOM images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         ko build ./cmd/${{ matrix.component }} \
           --base-import-paths \
           --image-refs=.digest \
-          --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
+          --tags=$UNIQUE_TAG # --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
 
         image=$(cat .digest | cut -d'@' -f1 | cut -d':' -f1)
         digest=$(cat .digest| cut -d'@' -f2)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  pull_request:
+    branches:
+    - main
   push:
     branches:
     - main
@@ -20,14 +23,21 @@ jobs:
     outputs:
       informer_image: ${{ steps.release.outputs.informer_image }}
       informer_digest: ${{ steps.release.outputs.informer_digest }}
+      informer_sbom_image: ${{ steps.release.outputs.informer_sbom_image }}
+      informer_sbom_digest: ${{ steps.release.outputs.informer_sbom_digest }}
+
       webhook_image: ${{ steps.release.outputs.webhook_image }}
       webhook_digest: ${{ steps.release.outputs.webhook_digest }}
+      webhook_sbom_image: ${{ steps.release.outputs.webhook_sbom_image }}
+      webhook_sbom_digest: ${{ steps.release.outputs.webhook_sbom_digest }}
 
     steps:
     - uses: actions/setup-go@v4
       with:
         go-version: 1.21.x
     - uses: ko-build/setup-ko@v0.6
+    - name: Install crane
+      run: go install github.com/google/go-containerregistry/cmd/crane@v0.19.1
     - uses: actions/checkout@v4
 
     - id: release
@@ -47,6 +57,14 @@ jobs:
         digest=$(cat .digest| cut -d'@' -f2)
         echo "${{ matrix.component }}_image=$image" >> "$GITHUB_OUTPUT"
         echo "${{ matrix.component }}_digest=$digest" >> "$GITHUB_OUTPUT"
+
+        # this is probably not the best way to sign the SBOM:
+        # - requires crane to get the SBOM image pushed above
+        # - is vulnerable to TOCTOU attacks if someone updates the sbom between "ko build" and now
+        # but, it's good enough for now, until I have a better solution
+        sbom_digest=$(crane digest $image:sha256-$digest.sbom)
+        echo "${{ matrix.component }}_sbom_image=$image" >> "$GITHUB_OUTPUT"
+        echo "${{ matrix.component }}_sbom_digest=$sbom_digest" >> "$GITHUB_OUTPUT"
   
   # see https://github.com/slsa-framework/slsa-github-generator/blob/v1.10.0/internal/builders/container/README.md#ko
   provenance:
@@ -56,7 +74,9 @@ jobs:
       matrix:
         component:
         - informer
+        - informer_sbom
         - webhook
+        - webhook_sbom
     permissions:
       actions: read
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    branches:
-    - main
   push:
     branches:
     - main
@@ -51,7 +48,7 @@ jobs:
         ko build ./cmd/${{ matrix.component }} \
           --base-import-paths \
           --image-refs=.digest \
-          --tags=$UNIQUE_TAG # --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
+          --tags=$GITHUB_REF_NAME,$UNIQUE_TAG
 
         image=$(cat .digest | cut -d'@' -f1 | cut -d':' -f1)
         digest=$(cat .digest| cut -d'@' -f2)
@@ -60,7 +57,7 @@ jobs:
 
         # this is probably not the best way to sign the SBOM:
         # - requires crane to get the SBOM image pushed above
-        # - is vulnerable to TOCTOU attacks if someone updates the sbom between "ko build" and now
+        # - is vulnerable to TOCTOU attacks if someone updates the sbom between "ko build" and "crane digest"
         # but, it's good enough for now, until I have a better solution
         sbom_digest=$(crane digest $image:sha256-$(echo $digest | cut -d':' -f2).sbom)
         echo "${{ matrix.component }}_sbom_image=$image" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         # - requires crane to get the SBOM image pushed above
         # - is vulnerable to TOCTOU attacks if someone updates the sbom between "ko build" and now
         # but, it's good enough for now, until I have a better solution
-        sbom_digest=$(crane digest $image:sha256-$digest.sbom)
+        sbom_digest=$(crane digest $image:sha256-$(echo $digest | cut -d':' -f2).sbom)
         echo "${{ matrix.component }}_sbom_image=$image" >> "$GITHUB_OUTPUT"
         echo "${{ matrix.component }}_sbom_digest=$sbom_digest" >> "$GITHUB_OUTPUT"
   


### PR DESCRIPTION
Sign SBOM images using SLSA generator (like we are signing other images). This ensures provenance of SBOM images.

Example:

```shell
IMAGE=ghcr.io/norbjd/k8s-pod-cpu-booster/webhook
TAG=202403261508-695a2eb
DIGEST=$(crane digest "$IMAGE:$TAG" | cut -d':' -f2)

# check the image (optional)
slsa-verifier verify-image "$IMAGE@sha256:$DIGEST" --source-uri github.com/norbjd/k8s-pod-cpu-booster

# check the SBOM image
SBOM_IMAGE=$IMAGE:sha256-$IMAGE_DIGEST.sbom
SBOM_IMAGE="${SBOM_IMAGE}@"$(crane digest "${SBOM_IMAGE}")
slsa-verifier verify-image "$SBOM_IMAGE" --source-uri github.com/norbjd/k8s-pod-cpu-booster
```

Result:

```
Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v1.10.0" at commit 695a2eb85489ad11f474a8de2834f4e6e7c62389
PASSED: Verified SLSA provenance
```

It would have been useful that `ko` puts the `sbom` image pushed in `.digest` file (`--image-refs` parameter). But it's not the case today so we have to deal with it.